### PR TITLE
Improve interactions with Laravel assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ Simply add the "\BinaryCabin\LaravelUUID\Traits\HasUUID;" trait to your model:
 
 namespace App;
 
+use BinaryCabin\LaravelUUID\Traits\HasUUID;
 use Illuminate\Database\Eloquent\Model;
 
 class Project extends Model
 {
 
-    use \BinaryCabin\LaravelUUID\Traits\HasUUID;
+    use HasUUID;
 
 }
 ```
@@ -47,3 +48,24 @@ And static find method:
 ```php
 \App\Project::findByUUID('uuid')
 ```
+
+A second trait is available if you use your UUIDs as primary keys:
+
+```php
+<?php
+
+namespace App;
+
+use BinaryCabin\LaravelUUID\Traits\HasUUID;
+use BinaryCabin\LaravelUUID\Traits\UUIDIsPrimaryKey;
+use Illuminate\Database\Eloquent\Model;
+
+class Project extends Model
+{
+
+    use HasUUID, UUIDIsPrimaryKey;
+
+}
+```
+
+It simply tells Laravel that your primary key isn't an auto-incrementing integer, so it will treat the value correctly.

--- a/src/Traits/UUIDIsPrimaryKey.php
+++ b/src/Traits/UUIDIsPrimaryKey.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BinaryCabin\LaravelUUID\Traits;
+
+trait UUIDIsPrimaryKey
+{
+    public function getIncrementing()
+    {
+        return false;
+    }
+
+    public function getKeyType()
+    {
+        return 'string';
+    }
+}


### PR DESCRIPTION
Adds a second trait, with functionality provided for reasons cited in [this article](https://dev.to/wilburpowery/easily-use-uuids-in-laravel-45be):

- The `getIncrementing()` method is used by Eloquent to know if the IDs on the table are incrementing. Remember we are using UUIDs, so we set auto-incrementing to false.
- The `getKeyType()` method just specifies that the IDs on the table should be stored as strings.